### PR TITLE
add license to TOML and fix the author list according to PEP 621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,14 @@ build-backend = "hatchling.build"
 [project]
 name = "mGST"
 version = "0.1.0"
-authors = [Raphael Brieger, Pau Dietz Romero]
+license = "MIT"
+
+[[project.authors]]
+name = "Raphael Brieger"
+[[project.authors]]
+name = "Pau Dietz Romero"
+
+
 description = "Gate Set Tomography"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
@rabrie 

I fixed the author list in the TOML file according to PEP 621.
This resolves a TOMLDecodeError when installing the package with pip.
Also the license was missing in the TOML.